### PR TITLE
Pass containerd_snapshotter to bootstrap ctr run nginx

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -78,6 +78,7 @@
   command: >-
     ctr --namespace=k8s.io run
     --net-host
+    --snapshotter={{ containerd_snapshotter }}
     -d
     --mount type=bind,src={{ nginx_config_dir }},dst=/etc/nginx,options=rbind:ro
     {{ nginx_image_repo }}:{{ nginx_image_tag }}


### PR DESCRIPTION
Fixes a regression in worker cycling or creation that we discovered in `flamingo` ([FOUND-794](https://linear.app/far-ai/issue/FOUND-794/kubespray-submodule-lost-snapshotterzfs-patch-blocking-bringup-on-zfs)).

The fix just adds `--snapshotter={{ containerd_snapshotter }}` to the bootstrap `ctr run nginx` in `roles/kubernetes/kubeadm/tasks/main.yml`. Without this it tries to use overlayfs instead of zfs and fails.