### PR TITLE
Emit transfer.v1.local unpack_config for containerd_snapshotter

### DIFF
--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -1,5 +1,7 @@
 version = 3
 
+imports = ["/etc/containerd/conf.d/*.toml"]
+
 root = "{{ containerd_storage_dir }}"
 state = "{{ containerd_state_dir }}"
 oom_score = {{ containerd_oom_score }}
@@ -87,6 +89,12 @@ oom_score = {{ containerd_oom_score }}
 
   [plugins."io.containerd.nri.v1.nri"]
     disable = {{ 'false' if nri_enabled else 'true' }}
+
+  [plugins."io.containerd.transfer.v1.local"]
+    [[plugins."io.containerd.transfer.v1.local".unpack_config]]
+      differ = ""
+      platform = "linux/amd64"
+      snapshotter = "{{ containerd_snapshotter }}"
 
 {% if containerd_tracing_enabled %}
   [plugins."io.containerd.tracing.processor.v1.otlp"]


### PR DESCRIPTION
## Summary

- Adds `[plugins."io.containerd.transfer.v1.local"]` block with `unpack_config` parameterised on `containerd_snapshotter`. Without this, containerd 2.2.2 logs `Unpack configuration not supported, skipping` and image pulls on ZFS workers fail with `unable to initialize unpacker: no unpack platforms defined`.
- Adds `imports = ["/etc/containerd/conf.d/*.toml"]` at the top of the config so post-bringup drop-ins (e.g. nvidia toolkit's `99-nvidia.toml`) are picked up without a second manual edit.

Companion patch to #4 (FOUND-794), which fixed the bootstrap `ctr run` snapshotter side; this PR fixes the daemon-config side. Together they remove the manual post-bringup containerd patch we've been doing on every fresh ZFS worker.

Linear: [FOUND-795](https://linear.app/far-ai/issue/FOUND-795/containerd-config-missing-transferv1local-unpack-config-for-zfs)